### PR TITLE
fix(webpack-ssr): missing env for ssr prod build

### DIFF
--- a/skeleton-typescript-webpack-ssr/package-scripts.js
+++ b/skeleton-typescript-webpack-ssr/package-scripts.js
@@ -61,7 +61,7 @@ module.exports = {
           ),
           ssr: series(
             'nps webpack.build.before',
-            'webpack --progress -p --env.production --env.extractCss',
+            'webpack --progress -p --env.production --env.extractCss --env.ssr',
             'webpack --config webpack.server.config.js --progress -p --env.production --env.extractCss'
           )
         }


### PR DESCRIPTION
The production build task was missing the `ssr` environment variable, meaning the condition for building the `index.ssr.html` file in `webpack.config.js` was not being met.